### PR TITLE
Update from base

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -304,3 +304,4 @@ dev/nuget/nuget.exe
 .vscode/tasks.json
 tests/data/sample.csproj
 src/ScottPlot/ScottPlot.xml
+src/ScottPlot4/ScottPlot/ScottPlot.xml

--- a/src/ScottPlot4/ScottPlot/Renderable/Axis.cs
+++ b/src/ScottPlot4/ScottPlot/Renderable/Axis.cs
@@ -142,7 +142,7 @@ namespace ScottPlot.Renderable
             {
                 AxisTicks.Render(dims, bmp, lowQuality);
                 AxisLabel.Render(dims, bmp, lowQuality);
-                AxisLine.Render(dims, bmp, lowQuality);
+                AxisLine.Render(dims, bmp, AxisTicks.SnapPx || lowQuality);
             }
         }
 

--- a/src/ScottPlot4/ScottPlot/ScottPlot.xml
+++ b/src/ScottPlot4/ScottPlot/ScottPlot.xml
@@ -5194,6 +5194,12 @@
             Return the point and rotation representing the center of the base of this axis
             </summary>
         </member>
+        <member name="F:ScottPlot.Renderable.AxisTicks.SnapPx">
+            <summary>
+            If true, grid lines will be drawn with anti-aliasing off to give the appearance of "snapping"
+            to the nearest pixel and to avoid blurriness associated with drawing single-pixel anti-aliased lines.
+            </summary>
+        </member>
         <member name="T:ScottPlot.Renderable.IRenderable">
             <summary>
             A "renderable" is any object which can be drawn on the figure.

--- a/src/ScottPlot4/changelog.md
+++ b/src/ScottPlot4/changelog.md
@@ -3,6 +3,7 @@
 ## ScottPlot 4.1.35
 _In development / not yet on NuGet ..._
 * Eto.Forms: Improved handling of events (#1719, #1718) _Thanks @rafntor and @VPKSoft_
+* Axis: Allow grid line and tick mark pixel snapping to be disabled (#1721, #1722) _Thanks @Xerxes004_
 
 ## ScottPlot 4.1.34
 _Published on [NuGet](https://www.nuget.org/packages?q=scottplot) on 2022-03-03_


### PR DESCRIPTION
**Purpose:**
Fixes usage of `AxisTick.SnapPx` so that tick lines and lines appear crisp and clean, as intended.

See #1721 